### PR TITLE
feat: Field description on create post can be an empty string

### DIFF
--- a/apps/gateway/src/features/post/dto/createPost.dto.ts
+++ b/apps/gateway/src/features/post/dto/createPost.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  Matches,
-  Length,
-  IsString,
-  IsNotEmpty,
-  IsArray,
   ArrayNotEmpty,
+  IsArray,
+  IsString,
+  Length,
+  Matches,
+  ValidateIf,
 } from 'class-validator';
 import { ERROR_LENGTH_DESCRIPTION } from '../post.constants';
 
@@ -16,7 +16,7 @@ export class CreatePostDto {
   images: string[];
 
   @ApiProperty({
-    description: 'Post description',
+    description: 'Post description, it can be an empty string',
     type: 'string',
     example: 'post_content',
     minLength: 3,
@@ -26,6 +26,6 @@ export class CreatePostDto {
   @Matches('^[a-zA-Z0-9_-\\s]*$')
   @Length(3, 500, { message: ERROR_LENGTH_DESCRIPTION })
   @IsString()
-  @IsNotEmpty()
+  @ValidateIf((o) => o.description !== '')
   description: string;
 }

--- a/apps/gateway/test/e2e.tests/post.e2e.spec.ts
+++ b/apps/gateway/test/e2e.tests/post.e2e.spec.ts
@@ -131,9 +131,11 @@ describe('PostController (e2e) test', () => {
         );
 
         const createPostDto = postTestHelper.postDto();
+
         const createdPost = await postTestHelper.createPost(
           accessToken,
-          createPostDto,
+          // Проверка на пустое описание первово созданного поста
+          i === 0 ? { ...createPostDto, description: '' } : createPostDto,
           {
             expectedCode: HttpStatus.CREATED,
           },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for post creation, allowing an empty string for the description field.

- **Tests**
  - Updated end-to-end tests for post creation to include scenarios with an empty description field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->