### PR TITLE
feat: Return empty array if posts is not created instead not found error

### DIFF
--- a/apps/gateway/src/features/post/api/publicPost.controller.ts
+++ b/apps/gateway/src/features/post/api/publicPost.controller.ts
@@ -42,7 +42,7 @@ export class PublicPostController {
     @Param('id') userId: string,
   ) {
     const posts = await this.postQueryRepo.getPosts(query, userId);
-    console.log(posts);
+
     if (!posts.isSuccess) {
       throw new NotFoundError(ERROR_POST_NOT_FOUND);
     }

--- a/apps/gateway/src/features/post/db/post.query.repository.ts
+++ b/apps/gateway/src/features/post/db/post.query.repository.ts
@@ -51,6 +51,14 @@ export class PostQueryRepository {
 
     if (userId) {
       whereClause.authorId = userId;
+
+      const user = await this.prismaService.user.findUnique({
+        where: { id: userId },
+      });
+
+      if (!user) {
+        return Result.Err(ERROR_POST_NOT_FOUND);
+      }
     }
 
     const posts = await this.prismaService.post.findMany({
@@ -62,7 +70,7 @@ export class PostQueryRepository {
     });
 
     if (!posts.length) {
-      return Result.Err(new NotFoundError(ERROR_POST_NOT_FOUND));
+      return Result.Ok([]);
     }
 
     const imageIds = posts.flatMap((post) =>

--- a/apps/gateway/test/e2e.tests/post.e2e.spec.ts
+++ b/apps/gateway/test/e2e.tests/post.e2e.spec.ts
@@ -20,6 +20,7 @@ import { PostQueryDto } from '@gateway/src/features/post/dto/postQuery.dto';
 import { ERROR_GET_URLS_FILES } from '@gateway/src/core/adapters/fileService/fileService.constants';
 import { EmailAdapter } from '@gateway/src/core/email-manager/email.adapter';
 import { randomUUID } from 'crypto';
+import { JwtAdapter } from '@gateway/src/core/jwt-adapter/jwt.adapter';
 
 jest.setTimeout(15000);
 
@@ -28,6 +29,7 @@ describe('PostController (e2e) test', () => {
   let authTestHelper: AuthTestHelper;
   let postTestHelper: IPostTestHelper;
   let fileServiceAdapter: FileServiceAdapter;
+  let jwtAdapter: JwtAdapter;
   const posts: Post[] = [];
 
   const emailAdapterMock = {
@@ -45,6 +47,8 @@ describe('PostController (e2e) test', () => {
 
     fileServiceAdapter =
       testingModule.get<FileServiceAdapter>(FileServiceAdapter);
+
+    jwtAdapter = testingModule.get<JwtAdapter>(JwtAdapter);
 
     app = await getAppForE2ETesting(testingModule);
 
@@ -208,6 +212,25 @@ describe('PostController (e2e) test', () => {
       const posts = await postTestHelper.getPosts({}, post.authorId);
 
       expect(posts.body.length).not.toBe(4);
+    });
+
+    it('should get empty posts by user id', async () => {
+      const { userId } = jwtAdapter.decodeToken(accesTokenSecondUser);
+
+      expect(userId).not.toBeUndefined();
+
+      jest.spyOn(fileServiceAdapter, 'getFilesInfo').mockReturnValueOnce(
+        Result.Ok([
+          {
+            ownerId: userId,
+            url: 'url',
+          },
+        ]) as any,
+      );
+
+      const posts = await postTestHelper.getPosts({}, userId);
+
+      expect(posts.body.length).toBe(0);
     });
 
     it('should get error if get posts by invalid user id', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty post results by returning an empty array instead of an error message.
- **Refactor**
  - Removed a console log statement in the `PublicPostController` class.
- **Tests**
  - Added import for `JwtAdapter` and utilized it in test cases in the `post.e2e.spec.ts` file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->